### PR TITLE
Add Read the Docs file for page hosting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+   image: latest
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+   install:
+   - requirements: docs/requirements.txt
+   - method: setuptools
+     path: .
+
+formats: []

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+https://download.pytorch.org/whl/cpu/torch-1.9.0%2Bcpu-cp38-cp38-linux_x86_64.whl
+https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_scatter-2.0.8-cp38-cp38-linux_x86_64.whl
+https://data.pyg.org/whl/torch-1.9.0%2Bcpu/torch_sparse-0.6.12-cp38-cp38-linux_x86_64.whl
+torch-geometric==2.0.1
+mkdocs-material
+mkdocstrings


### PR DESCRIPTION
Add two files for page hosting in Read the Docs.
1. .readthedocs.yaml -- the configuration file for Read the Docs.
2. docs/requirements.txt -- the requirements for Python. Due to the different requirements of this project and MkDocs, we need another requirements.txt file.